### PR TITLE
version bump for 1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Contributors: norcross, jjeaton, reaktivstudios
 Requires at least: 4.0
 Tested up to: 5.5
-Stable tag: 1.0.6
+Stable tag: 1.0.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -27,6 +27,10 @@ Install and activate it.
 ## Screenshots
 
 ## Changelog
+
+### 1.0.5: 2020-09-08
+
+* Added support for some blocks in the entry content.
 
 ### 1.0.4: 2017-02-01
 

--- a/gppro-entry-content.php
+++ b/gppro-entry-content.php
@@ -4,7 +4,7 @@ Plugin Name: Genesis Design Palette Pro - Entry Content
 Plugin URI: https://genesisdesignpro.com/
 Description: Fine tune the look of the content inside posts and pages in Genesis Design Palette Pro
 Author: Reaktiv Studios
-Version: 1.0.6
+Version: 1.0.5
 Requires at least: 4.0
 Author URI: https://genesisdesignpro.com
 */
@@ -38,7 +38,7 @@ if ( ! defined( 'GPECN_DIR' ) ) {
 
 // Set our plugin version as a constant.
 if ( ! defined( 'GPECN_VER' ) ) {
-	define( 'GPECN_VER', '1.0.5-dev' );
+	define( 'GPECN_VER', '1.0.5' );
 }
 
 /**
@@ -2164,4 +2164,3 @@ class GP_Pro_Entry_Content
 
 // Instantiate our class.
 $GP_Pro_Entry_Content = GP_Pro_Entry_Content::getInstance();
-


### PR DESCRIPTION
fixes version sync with what is in production and the small update included in the latest code.

Previously there were 1.0.4 in prod and a mix of 1.0.5 and 1.0.6 in git.

@reaktivstudios/reviewers this is ready to review 